### PR TITLE
Feature/gentex homelink reauth flow

### DIFF
--- a/homeassistant/components/gentex_homelink/config_flow.py
+++ b/homeassistant/components/gentex_homelink/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for homelink."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -54,7 +55,10 @@ class SRPFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
                 _LOGGER.exception("An unexpected error occurred")
                 errors["base"] = "unknown"
             else:
-                self.external_data = {"tokens": tokens}
+                self.external_data = {
+                    "tokens": tokens,
+                    CONF_EMAIL: user_input[CONF_EMAIL].lower(),
+                }
                 return await self.async_step_creation()
 
         return self.async_show_form(
@@ -64,3 +68,36 @@ class SRPFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> config_entries.ConfigFlowResult:
+        """Perform reauth upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Dialog that informs the user that reauth is required."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+                ),
+            )
+        return await self.async_step_user()
+
+    async def async_oauth_create_entry(
+        self, data: dict
+    ) -> config_entries.ConfigFlowResult:
+        """Create an oauth config entry or update existing entry for reauth."""
+        await self.async_set_unique_id(data["token"][CONF_EMAIL])
+        if self.source == config_entries.SOURCE_REAUTH:
+            self._abort_if_unique_id_mismatch()
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(),
+                data_updates=data,
+            )
+        self._abort_if_unique_id_configured()
+        return await super().async_oauth_create_entry(data)

--- a/homeassistant/components/gentex_homelink/config_flow.py
+++ b/homeassistant/components/gentex_homelink/config_flow.py
@@ -86,7 +86,7 @@ class SRPFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
                     {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
                 ),
             )
-        return await self.async_step_user()
+        return await self.async_step_user(user_input)
 
     async def async_oauth_create_entry(
         self, data: dict

--- a/homeassistant/components/gentex_homelink/const.py
+++ b/homeassistant/components/gentex_homelink/const.py
@@ -1,7 +1,9 @@
 """Constants for the homelink integration."""
 
 DOMAIN = "gentex_homelink"
-OAUTH2_TOKEN = "https://auth.homelinkcloud.com/oauth2/token"
+OAUTH2_TOKEN = (
+    "https://hl-userpool-naelick-sandbox.auth.us-east-2.amazoncognito.com/oauth2/token"
+)
 POLLING_INTERVAL = 5
 
 EVENT_PRESSED = "Pressed"

--- a/homeassistant/components/gentex_homelink/const.py
+++ b/homeassistant/components/gentex_homelink/const.py
@@ -1,9 +1,7 @@
 """Constants for the homelink integration."""
 
 DOMAIN = "gentex_homelink"
-OAUTH2_TOKEN = (
-    "https://hl-userpool-naelick-sandbox.auth.us-east-2.amazoncognito.com/oauth2/token"
-)
+OAUTH2_TOKEN = "https://auth.homelinkcloud.com/oauth2/token"
 POLLING_INTERVAL = 5
 
 EVENT_PRESSED = "Pressed"

--- a/homeassistant/components/gentex_homelink/oauth2.py
+++ b/homeassistant/components/gentex_homelink/oauth2.py
@@ -9,6 +9,7 @@ from aiohttp import ClientError, ClientSession
 from homelink.auth.abstract_auth import AbstractAuth
 from homelink.settings import COGNITO_CLIENT_ID
 
+from homeassistant.const import CONF_EMAIL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -53,6 +54,7 @@ class SRPAuthImplementation(config_entry_oauth2_flow.AbstractOAuth2Implementatio
         new_token["expires_at"] = (
             time.time() + tokens["AuthenticationResult"]["ExpiresIn"]
         )
+        new_token[CONF_EMAIL] = external_data[CONF_EMAIL]
 
         return new_token
 

--- a/homeassistant/components/gentex_homelink/strings.json
+++ b/homeassistant/components/gentex_homelink/strings.json
@@ -11,6 +11,7 @@
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unique_id_mismatch": "Please log in using the same account, or create a new entry.",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },
     "create_entry": {

--- a/homeassistant/components/gentex_homelink/strings.json
+++ b/homeassistant/components/gentex_homelink/strings.json
@@ -10,6 +10,7 @@
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },
     "create_entry": {
@@ -22,6 +23,18 @@
     "step": {
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "Email address associated with your HomeLink account",
+          "password": "Password associated with your HomeLink account"
+        },
+        "description": "The HomeLink integration needs to re-authenticate your account",
+        "title": "[%key:common::config_flow::title::reauth%]"
       },
       "user": {
         "data": {

--- a/tests/components/gentex_homelink/test_config_flow.py
+++ b/tests/components/gentex_homelink/test_config_flow.py
@@ -1,13 +1,19 @@
 """Test the homelink config flow."""
 
+from http import HTTPStatus
+import time
 from unittest.mock import patch
 
 import botocore.exceptions
 
 from homeassistant import config_entries
-from homeassistant.components.gentex_homelink.const import DOMAIN
+from homeassistant.components.gentex_homelink.const import DOMAIN, OAUTH2_TOKEN
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+from tests.conftest import AiohttpClientMocker
 
 
 async def test_show_user_form(hass: HomeAssistant) -> None:
@@ -21,7 +27,9 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.FORM
 
 
-async def test_full_flow(hass: HomeAssistant) -> None:
+async def test_full_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Check full flow."""
     with patch(
         "homeassistant.components.gentex_homelink.config_flow.SRPAuth"
@@ -42,6 +50,17 @@ async def test_full_flow(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input={"email": "test@test.com", "password": "SomePassword"},
         )
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(
+            OAUTH2_TOKEN,
+            json={
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "expires_at": time.time() + 3600,
+                "expires_in": 3600,
+            },
+        )
+
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"]
         assert result["data"]["token"]
@@ -49,6 +68,89 @@ async def test_full_flow(hass: HomeAssistant) -> None:
         assert result["data"]["token"]["refresh_token"] == "refresh"
         assert result["data"]["token"]["expires_in"] == 3600
         assert result["data"]["token"]["expires_at"]
+
+
+async def test_auth_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test if the auth server returns an error refreshing the token."""
+    with patch(
+        "homeassistant.components.gentex_homelink.config_flow.SRPAuth"
+    ) as MockSRPAuth:
+        instance = MockSRPAuth.return_value
+        instance.async_get_access_token.return_value = {
+            "AuthenticationResult": {
+                "AccessToken": "access",
+                "RefreshToken": "refresh",
+                "TokenType": "bearer",
+                "ExpiresIn": 3600,
+            }
+        }
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(OAUTH2_TOKEN, status=HTTPStatus.UNAUTHORIZED)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"email": "test@test.com", "password": "SomePassword"},
+        )
+
+
+async def test_reauth_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the reauth flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=None,
+        version=1,
+        data={
+            "auth_implementation": "gentex_homelink",
+            "token": {
+                "expires_at": time.time() + 10000,
+                "access_token": "",
+                "refresh_token": "",
+            },
+            "last_update_id": None,
+        },
+        state=config_entries.ConfigEntryState.LOADED,
+    )
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_EMAIL: "fake2@email.com", CONF_PASSWORD: "password"},
+    )
+
+
+async def test_reauth_new_email_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the flow where it isn't a reauth, it's a new sign in."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=None,
+        version=1,
+        data={
+            "auth_implementation": "gentex_homelink",
+            "token": {
+                "expires_at": time.time() + 10000,
+                "access_token": "",
+                "refresh_token": "",
+                CONF_EMAIL: "fake@email.com",
+            },
+            "last_update_id": None,
+        },
+        state=config_entries.ConfigEntryState.LOADED,
+    )
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_EMAIL: "fake2@email.com", CONF_PASSWORD: "password"},
+    )
 
 
 async def test_boto_error(hass: HomeAssistant) -> None:

--- a/tests/components/gentex_homelink/test_init.py
+++ b/tests/components/gentex_homelink/test_init.py
@@ -1,17 +1,19 @@
 """Test that the integration is initialized correctly."""
 
+import time
 from unittest.mock import patch
 
 from homeassistant.components import gentex_homelink
-from homeassistant.components.gentex_homelink.const import DOMAIN
+from homeassistant.components.gentex_homelink.const import DOMAIN, OAUTH2_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.conftest import AiohttpClientMocker
 
 
 async def test_load_unload_entry(
-    hass: HomeAssistant,
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the entry can be loaded and unloaded."""
     with patch("homeassistant.components.gentex_homelink.MQTTProvider", autospec=True):
@@ -19,10 +21,23 @@ async def test_load_unload_entry(
             domain=DOMAIN,
             unique_id=None,
             version=1,
-            data={"auth_implementation": "gentex_homelink"},
+            data={
+                "auth_implementation": "gentex_homelink",
+                "token": {"refresh_token": "refresh"},
+            },
         )
         entry.add_to_hass(hass)
 
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(
+            OAUTH2_TOKEN,
+            json={
+                "access_token": "updated-access-token",
+                "refresh_token": "updated-refresh-token",
+                "expires_at": time.time() + 3600,
+                "expires_in": 3600,
+            },
+        )
         assert await async_setup_component(hass, DOMAIN, {}) is True, (
             "Component is not set up"
         )


### PR DESCRIPTION
Add the reauth flow for homelink

To test:
1. Add the integration and log in to your cognito account
2. In AWS, log into cognito
3. Find the user you logged in with
4. Log that user out (Option in the top right of the user screen)
5. In Homeassistant, reload the integration

You should see a yellow box telling you you need to reauthorize

You can click on the box, put your credentials in again, and relogin.

This is the same case as if the refresh token expires (if you haven't logged in in a while)
